### PR TITLE
feat: getUserRankings based on revenue (#19)

### DIFF
--- a/src/main/java/Back/whats_your_ETF/controller/EtfController.java
+++ b/src/main/java/Back/whats_your_ETF/controller/EtfController.java
@@ -3,10 +3,13 @@ package Back.whats_your_ETF.controller;
 import Back.whats_your_ETF.dto.EtfRequest;
 import Back.whats_your_ETF.dto.PortfolioDetailsResponse;
 import Back.whats_your_ETF.dto.PortfolioListResponse;
+import Back.whats_your_ETF.dto.UserRankingResponse;
 import Back.whats_your_ETF.service.EtfService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,6 +46,13 @@ public class EtfController {
     public ResponseEntity<PortfolioListResponse> getPortfolioRank() {
         PortfolioListResponse response = etfService.getPortfolioRank();
         return ResponseEntity.ok(response);
+    }
+
+    //2.1.2 수익률 높은순으로 유저 랭킹
+    @GetMapping("/user/ranking")
+    public ResponseEntity<List<UserRankingResponse>> getUserRankings() {
+        List<UserRankingResponse> rankings = etfService.getUserRanking();
+        return ResponseEntity.ok(rankings);
     }
 
 

--- a/src/main/java/Back/whats_your_ETF/dto/UserRankingResponse.java
+++ b/src/main/java/Back/whats_your_ETF/dto/UserRankingResponse.java
@@ -1,0 +1,7 @@
+package Back.whats_your_ETF.dto;
+
+public record UserRankingResponse(
+        Long userId,
+        String nickname,
+        Double revenuePercentage
+) {}

--- a/src/main/java/Back/whats_your_ETF/repository/PortfolioRepository.java
+++ b/src/main/java/Back/whats_your_ETF/repository/PortfolioRepository.java
@@ -22,4 +22,8 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
     //포트폴리오 수익률별로 가져오기
     @Query("SELECT p FROM Portfolio p ORDER BY p.revenue DESC")
     List<Portfolio> findAllOrderByRevenueDesc();
+
+    //유저와 포트폴리오를 함께 가져오기
+    @Query("SELECT DISTINCT u FROM User u JOIN FETCH u.portfolioss")
+    List<User> findAllUsersWithPortfolios();
 }


### PR DESCRIPTION
### 세부내용
- ETF 수익률 높은순대로 가져오기
- 수익률 높은 사용자 랭킹
- ETF 수익률 계산 :
- 
<총 투자금액 >
유저가 가지고 있는 모든 ETF의 총 투자 금액의 합.
Total Invest Amount = Σ (Portfolio의 investAmount)

＜총 수익금액＞
유저가 가지고 있는 모든 ETF의 수익(현재 시세와 구매가의 차이)을 합한 값.
Total Revenue = Σ (현재 시세 - 구매가) × (보유 비율)

＜수익률＞
유저가 투자한 금액 대비 수익금액의 비율.
Revenue Percentage = (Total Revenue / Total Invest Amount) × 100