### PR TITLE
feat: save refreshtoken in redis (#36)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/back/whats_your_ETF/config/RedisConfig.java
+++ b/src/main/java/back/whats_your_ETF/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package back.whats_your_ETF.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(redisProperties.getHost());
+        config.setPort(redisProperties.getPort());
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/back/whats_your_ETF/config/RedisProperties.java
+++ b/src/main/java/back/whats_your_ETF/config/RedisProperties.java
@@ -1,0 +1,16 @@
+package back.whats_your_ETF.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@PropertySource("application.yml")
+public class RedisProperties {
+    @Value("${redis.port}")
+    private int port;
+    @Value("${redis.host}")
+    private String host;
+}

--- a/src/main/java/back/whats_your_ETF/service/UserAuthService.java
+++ b/src/main/java/back/whats_your_ETF/service/UserAuthService.java
@@ -7,6 +7,7 @@ import back.whats_your_ETF.entity.User;
 import back.whats_your_ETF.repository.RefreshTokenRepository;
 import back.whats_your_ETF.repository.UserRepository;
 import back.whats_your_ETF.util.JwtUtil;
+import back.whats_your_ETF.util.RedisUtil;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -17,57 +18,10 @@ public class UserAuthService {
 
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RedisUtil redisUtil;
     private final PasswordEncoder passwordEncoder;
 
-    public UserAuthService(JwtUtil jwtUtil, UserRepository userRepository,
-                           RefreshTokenRepository refreshTokenRepository, PasswordEncoder passwordEncoder) {
-        this.jwtUtil = jwtUtil;
-        this.userRepository = userRepository;
-        this.refreshTokenRepository = refreshTokenRepository;
-        this.passwordEncoder = passwordEncoder;
-    }
-
-    // 사용자 인증 및 토큰 발급
-    public TokenPair authenticate(String userId, String password) {
-        // 사용자 확인
-        User user = userRepository.findByUserId(userId)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
-
-        if (!passwordEncoder.matches(password, user.getPassword())) {
-            throw new BadCredentialsException("아이디 또는 비밀번호가 잘못되었습니다.");
-        }
-
-        // AccessToken과 RefreshToken 생성
-        TokenPair tokenPair = jwtUtil.generateToken(userId);
-
-//         RefreshToken 저장 (DB에 저장하거나 갱신)
-        saveOrUpdateRefreshToken(user, tokenPair.getRefreshToken());
-
-        return tokenPair;
-    }
-
-    // AccessToken 갱신
-    public TokenPair refreshAccessToken(String refreshToken) {
-        String userId = jwtUtil.extractUserId(refreshToken);
-
-        // RefreshToken 유효성 검증
-        RefreshToken storedToken = refreshTokenRepository.findByUserId(userId)
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 RefreshToken입니다."));
-
-        if (!storedToken.getRefreshToken().equals(refreshToken)) {
-            throw new IllegalArgumentException("RefreshToken이 일치하지 않습니다.");
-        }
-
-        if (jwtUtil.isTokenExpired(refreshToken)) {
-            throw new IllegalArgumentException("RefreshToken이 만료되었습니다.");
-        }
-
-        // 새로운 AccessToken과 기존 RefreshToken 반환
-        String newAccessToken = jwtUtil.generateAccessToken(userId);
-
-        return new TokenPair(newAccessToken, refreshToken);
-    }
+    private static final long REFRESH_TOKEN_TTL = 60 * 60 * 24 * 7; // 7일
 
     // 회원가입
     public void signup(SignUpRequest signUpRequest) {
@@ -87,12 +41,53 @@ public class UserAuthService {
         userRepository.save(user);
     }
 
-    // RefreshToken 저장 또는 갱신
-    private void saveOrUpdateRefreshToken(User user, String refreshToken) {
-        RefreshToken refreshTokenEntity = refreshTokenRepository.findByUserId(user.getUserId())
-                .orElse(new RefreshToken());
-        refreshTokenEntity.setUser(user);
-        refreshTokenEntity.setRefreshToken(refreshToken);
-        refreshTokenRepository.save(refreshTokenEntity);
+    public UserAuthService(JwtUtil jwtUtil, UserRepository userRepository,
+                           RedisUtil redisUtil, PasswordEncoder passwordEncoder) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+        this.redisUtil = redisUtil;
+        this.passwordEncoder = passwordEncoder;
     }
+
+    // RefreshToken 저장 또는 갱신
+    private void saveOrUpdateRefreshToken(String userId, String refreshToken) {
+        redisUtil.save(userId, refreshToken, REFRESH_TOKEN_TTL);
+    }
+
+    // RefreshToken 검증
+    private boolean validateRefreshToken(String userId, String refreshToken) {
+        String storedToken = redisUtil.get(userId);
+        return storedToken != null && storedToken.equals(refreshToken);
+    }
+
+    // 사용자 인증 및 토큰 발급
+    public TokenPair authenticate(String userId, String password) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BadCredentialsException("아이디 또는 비밀번호가 잘못되었습니다.");
+        }
+
+        TokenPair tokenPair = jwtUtil.generateToken(userId);
+        saveOrUpdateRefreshToken(userId, tokenPair.getRefreshToken());
+        return tokenPair;
+    }
+
+    // AccessToken 갱신
+    public TokenPair refreshAccessToken(String refreshToken) {
+        String userId = jwtUtil.extractUserId(refreshToken);
+
+        if (!validateRefreshToken(userId, refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 RefreshToken입니다.");
+        }
+
+        if (jwtUtil.isTokenExpired(refreshToken)) {
+            throw new IllegalArgumentException("RefreshToken이 만료되었습니다.");
+        }
+
+        String newAccessToken = jwtUtil.generateAccessToken(userId);
+        return new TokenPair(newAccessToken, refreshToken);
+    }
+
 }

--- a/src/main/java/back/whats_your_ETF/util/RedisUtil.java
+++ b/src/main/java/back/whats_your_ETF/util/RedisUtil.java
@@ -1,0 +1,26 @@
+package back.whats_your_ETF.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void save(String key, String value, long duration) {
+        redisTemplate.opsForValue().set(key, value, Duration.ofSeconds(duration));
+    }
+
+    public String get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,6 +28,9 @@ logging:
     root: info
     org.springframework.web: debug
 
+redis:
+  host: localhost
+  port: 6379
 
 APP_KEY: "PSmqu4Sv0FyEaup0qheHCN8ypL0y7L7jMx2R"
 APP_SECRET: "VeF7GB6itEg6Oax5N9TrSg31PF6+9lAsFyRiH3uDCNQE89fpTRjxyp1Q8DcAcef0gZNVDI/AwiaOUHDC0yqIZVnbKhHhuU84gRkz16p3XrAXnDLHLU+XlEjvSeJZh+/8kxE0tfLkKTz6oNCXT5H5qzFvThgdvuQkCMt15Ifja7/ksD6AtG8="


### PR DESCRIPTION
세부내용

- Redis를 활용하여 Refresh Token 저장 및 검증 로직을 구현.
- 기존 RDB를 사용하던 방식에서 Redis로 전환하여 로그인 및 토큰 갱신 속도 향상.
- RedisUtil을 사용한 토큰 저장 및 조회 구현.
- Refresh Token 저장 시 TTL(Time-To-Live) 설정 추가.
- UserAuthService 내 saveOrUpdateRefreshToken 및 validateRefreshToken 메서드에서 Redis로 저장/검증 처리.