### PR TITLE
feat: send profitspot,lossspot notification (#42)

### DIFF
--- a/src/main/java/back/whats_your_ETF/controller/NotificationController.java
+++ b/src/main/java/back/whats_your_ETF/controller/NotificationController.java
@@ -26,6 +26,4 @@ public class NotificationController {
         notificationService.addPortfolioNotification(request.userId(), request.portfolioId());
         return ResponseEntity.ok().build();
     }
-
-
 }

--- a/src/main/java/back/whats_your_ETF/dto/NoticeResponse.java
+++ b/src/main/java/back/whats_your_ETF/dto/NoticeResponse.java
@@ -1,0 +1,9 @@
+package back.whats_your_ETF.dto;
+
+
+public record NoticeResponse(
+        Long id,          // 알림 ID
+        String content,   // 알림 내용
+        boolean isRead,   // 읽음 여부
+        Long userId       // 사용자 ID
+) {}

--- a/src/main/java/back/whats_your_ETF/entity/Notice.java
+++ b/src/main/java/back/whats_your_ETF/entity/Notice.java
@@ -28,4 +28,7 @@ public class Notice extends BasicEntity {
 
     @Column(name = "is_read")
     private boolean isRead;
+
+    @Column(name = "is_sent")
+    private boolean isSent;
 }

--- a/src/main/java/back/whats_your_ETF/entity/Portfolio.java
+++ b/src/main/java/back/whats_your_ETF/entity/Portfolio.java
@@ -1,6 +1,7 @@
 package back.whats_your_ETF.entity;
 
 import back.whats_your_ETF.global.BasicEntity;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -22,6 +23,7 @@ public class Portfolio extends BasicEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @JsonBackReference
     private User user;
 
     @Column(name = "title", nullable = false)
@@ -40,8 +42,12 @@ public class Portfolio extends BasicEntity {
     private List<ETFStock> etfStocks;
 
     @Column(name = "profit_spot")
-    private Long profitSpot;
+    private Long profitSpot = 100L;
 
     @Column(name = "loss_spot")
-    private Long lossSpot;
+    private Long lossSpot = -100L;
+
+    @Column
+    private boolean alreadySend = false;
+
 }

--- a/src/main/java/back/whats_your_ETF/entity/User.java
+++ b/src/main/java/back/whats_your_ETF/entity/User.java
@@ -1,5 +1,6 @@
 package back.whats_your_ETF.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -47,6 +48,7 @@ public class User {
     private Boolean isInTop10;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<Portfolio> portfolioss;
 
     @OneToMany(mappedBy = "subscriber", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/back/whats_your_ETF/repository/NoticeRepository.java
+++ b/src/main/java/back/whats_your_ETF/repository/NoticeRepository.java
@@ -1,0 +1,13 @@
+package back.whats_your_ETF.repository;
+
+import back.whats_your_ETF.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    List<Notice> findAllByUserIdAndIsReadFalse(Long userId);
+}
+

--- a/src/main/java/back/whats_your_ETF/service/NotificationService.java
+++ b/src/main/java/back/whats_your_ETF/service/NotificationService.java
@@ -1,11 +1,16 @@
 package back.whats_your_ETF.service;
 
+import back.whats_your_ETF.dto.NoticeResponse;
 import back.whats_your_ETF.dto.PortfolioResponse;
+import back.whats_your_ETF.entity.Notice;
 import back.whats_your_ETF.entity.Portfolio;
 import back.whats_your_ETF.repository.EmitterRepository;
+import back.whats_your_ETF.repository.NoticeRepository;
 import back.whats_your_ETF.repository.PortfolioRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.embedded.netty.NettyWebServer;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -21,6 +26,7 @@ public class NotificationService {
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60; // 60분
     private final EmitterRepository emitterRepository;
     private final PortfolioRepository portfolioRepository;
+    private final NoticeRepository noticeRepository;
     private final EtfService etfService;
 
     // SSE 연결 설정
@@ -63,14 +69,19 @@ public class NotificationService {
                 portfolio.setRevenue(newRevenue);
                 portfolioRepository.save(portfolio);
 
+                // PortfolioResponse 생성 및 SSE 전송
                 PortfolioResponse response = new PortfolioResponse(
                         portfolio.getId(),
                         portfolio.getTitle(),
                         newRevenue,
                         portfolio.getInvestAmount()
                 );
-                sendNotification(portfolio.getUser().getId(), response);
+                sendPortfolioUpdateNotification(portfolio.getUser().getId(), response);
                 emitterRepository.updateRevenueCache(portfolio.getId(), newRevenue);
+            }
+            // 익절/손절 Spot 알림
+            if ((newRevenue >= portfolio.getProfitSpot() || newRevenue <= portfolio.getLossSpot()) && !portfolio.isAlreadySend()) {
+                sendProfitLossSpotNotification(portfolio, newRevenue);
             }
         }
     }
@@ -79,6 +90,56 @@ public class NotificationService {
         Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(String.valueOf(userId));
         sseEmitters.forEach((key, emitter) -> sendToClient(emitter, key, response));
     }
+
+    //실시간 portfolio수익률 변동알림
+    private void sendPortfolioUpdateNotification(Long userId, PortfolioResponse response) {
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(String.valueOf(userId));
+        sseEmitters.forEach((key, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event().id(key).name("portfolio-update").data(response));
+            } catch (IOException exception) {
+                emitterRepository.deleteById(key);
+            }
+        });
+    }
+
+    //손익,손절spot 알림 생성
+    private void sendProfitLossSpotNotification(Portfolio portfolio, double newRevenue) {
+        String message = newRevenue >= portfolio.getProfitSpot()
+                ? "수익률이 목표치에 도달했습니다!"
+                : "손실률이 설정한 한도에 도달했습니다!";
+
+        // Notice 저장
+        Notice notice = Notice.builder()
+                .user(portfolio.getUser())
+                .content("[" + portfolio.getTitle() + "] " + message)
+                .isRead(false)
+                .build();
+        noticeRepository.save(notice);
+
+        // NoticeResponse 생성 및 SSE 전송
+        NoticeResponse response = new NoticeResponse(
+                notice.getId(),
+                notice.getContent(),
+                notice.isRead(),
+                notice.getUser().getId()
+        );
+        sendNotice(portfolio.getUser().getId(), response);
+//        portfolio.setAlreadySend(true);
+    }
+    //익절,손절 알림전송
+    private void sendNotice(Long userId, NoticeResponse response) {
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById(String.valueOf(userId));
+        sseEmitters.forEach((key, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event().id(key).name("notice").data(new ObjectMapper().writeValueAsString(response)));
+            } catch (IOException exception) {
+                emitterRepository.deleteById(key);
+            }
+        });
+    }
+
+
 
     private void sendToClient(SseEmitter emitter, String id, PortfolioResponse response) {
         try {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,5 +1,4 @@
 spring:
-
   config:
     import: optional:file:.env
 
@@ -12,13 +11,19 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: trueportfolio
   sql:
     init:
       mode: always
+
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
 
 server:
   port: 8080


### PR DESCRIPTION
### 요약
ETF의 수익률 변동이 익절/손절 기준에 도달했을 때 사용자에게 실시간으로 알림을 전송하는 기능을 구현했습니다.

### 주요 변경 사항
1. 익절/손절 알림 기능 구현
- 포트폴리오의 profitSpot(익절) 또는 lossSpot(손절)에 도달 시 사용자에게 알림 전송.
- 알림 정보는 Notice 엔티티에 저장되며, 사용자 SSE 연결을 통해 실시간으로 전달.

2. 코드 구조 변경
- 수익률 변동 알림과 익절/손절 알림 로직 분리
- sendProfitLossSpotNotification 메서드 추가:
- 알림 메시지 생성 및 저장 후 SSE를 통해 사용자에게 전송.

3. 알림 저장 로직
- 익절/손절 알림 발생 시 Notice 엔티티에 저장.
- 저장된 알림은 사용자가 로그인 시 확인 가능.