### PR TITLE
fix: 매일자정에 alreadySend초기화 (#42)

### DIFF
--- a/src/main/java/back/whats_your_ETF/service/NotificationService.java
+++ b/src/main/java/back/whats_your_ETF/service/NotificationService.java
@@ -54,6 +54,18 @@ public class NotificationService {
         }
     }
 
+    // 매일 자정에 alreadySend 초기화
+    @Scheduled(cron = "0 0 0 * * ?")
+    @Transactional
+    public void resetAlreadySendFlags() {
+        List<Portfolio> portfolios = portfolioRepository.findAll();
+        for (Portfolio portfolio : portfolios) {
+            portfolio.setAlreadySend(false);
+        }
+        portfolioRepository.saveAll(portfolios);
+        System.out.println("알림 전송 플래그 초기화 완료");
+    }
+
     // Portfolio 수익률 변동 알림
     @Scheduled(fixedRate = 5000) // 5초마다 실행
     @Transactional


### PR DESCRIPTION
## 변경사항
### 수익률 변동 알림 (PortfolioResponse)
- 알림 전송 횟수를 하루에 한 번으로 제한하기 위해 Portfolio 엔티티에 alreadySend 필드를 추가했습니다.
- 스케줄러가 매일 00시에 모든 Portfolio의 alreadySend 값을 false로 초기화하여 다음 날 알림 전송이 가능하도록 처리했습니다.
 
### 정리
- 수익률 변동 알림 (PortfolioResponse)은 기존과 동일하게 즉시 전송.
- 익절/손절 알림 (NoticeResponse)은 하루에 한 번만 전송.