### PR TITLE
Feat: 실시간 주식 시세 변동 비율 알림 기능 추가

### DIFF
--- a/src/main/java/back/whats_your_ETF/controller/StockListController.java
+++ b/src/main/java/back/whats_your_ETF/controller/StockListController.java
@@ -1,7 +1,6 @@
 package back.whats_your_ETF.controller;
 
 import back.whats_your_ETF.dto.StockRankResponse;
-import back.whats_your_ETF.dto.StockResponse;
 import back.whats_your_ETF.service.StockListService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/back/whats_your_ETF/controller/StockUpdatesController.java
+++ b/src/main/java/back/whats_your_ETF/controller/StockUpdatesController.java
@@ -1,0 +1,21 @@
+package back.whats_your_ETF.controller;
+
+import back.whats_your_ETF.service.StockListService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stock-updates")
+public class StockUpdatesController {
+
+    private final StockListService stockListService;
+
+    @GetMapping("/subscribe")
+    public SseEmitter subscribeToStockUpdates() {
+        return stockListService.subscribeToStockUpdates();
+    }
+}

--- a/src/main/java/back/whats_your_ETF/controller/UserController.java
+++ b/src/main/java/back/whats_your_ETF/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     }
 
     //멤버십 해지하기
-    @DeleteMapping("/membership")
+    @DeleteMapping("/membership/{user_id}")
     public ResponseEntity<String> deleteMembership(@PathVariable("user_id") Long userId) {
         return userService.deleteMembership(userId);
     }

--- a/src/main/java/back/whats_your_ETF/dto/StockRankResponse.java
+++ b/src/main/java/back/whats_your_ETF/dto/StockRankResponse.java
@@ -4,5 +4,5 @@ public record StockRankResponse (
         String stockCode,
         String stockName,
         Double price,
-        Double percentage
+        Double priceChangeRate
 ) {}

--- a/src/main/java/back/whats_your_ETF/entity/Ranking.java
+++ b/src/main/java/back/whats_your_ETF/entity/Ranking.java
@@ -62,7 +62,7 @@ public class Ranking extends BasicEntity {
     private Long priceChange; // 전일 대비 금액
 
     @Column(name = "price_change_rate", nullable = true)
-    private Long priceChangeRate; // 전일 대비 등락률
+    private Double priceChangeRate; // 전일 대비 등락률
 
     @Column(name = "profit", nullable = true)
     private Long profit; // 수익 지표 값

--- a/src/main/java/back/whats_your_ETF/repository/EmitterRepository.java
+++ b/src/main/java/back/whats_your_ETF/repository/EmitterRepository.java
@@ -15,6 +15,7 @@ public class EmitterRepository {
     private final Map<Long, List<Long>> userPortfolioPreferences = new ConcurrentHashMap<>();
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
     private final Map<Long, Double> portfolioRevenueCache = new ConcurrentHashMap<>();
+    private final Map<Long, Double> rankingPriceChangeRateCache = new ConcurrentHashMap<>(); // priceChangeRate 캐시
 
     public SseEmitter save(String id, SseEmitter emitter) {
         emitters.put(id, emitter);
@@ -49,5 +50,15 @@ public class EmitterRepository {
 
     public void updateRevenueCache(Long portfolioId, double newRevenue) {
         portfolioRevenueCache.put(portfolioId, newRevenue);
+    }
+
+    // priceChangeRate 캐시 값 가져오기
+    public Double getCachedPriceChangeRate(Long rankingId) {
+        return rankingPriceChangeRateCache.getOrDefault(rankingId, 0.0);
+    }
+
+    // priceChangeRate 캐시 값 업데이트
+    public void updateCachedPriceChangeRate(Long rankingId, Double newPriceChangeRate) {
+        rankingPriceChangeRateCache.put(rankingId, newPriceChangeRate);
     }
 }

--- a/src/main/java/back/whats_your_ETF/service/NotificationService.java
+++ b/src/main/java/back/whats_your_ETF/service/NotificationService.java
@@ -10,7 +10,6 @@ import back.whats_your_ETF.repository.PortfolioRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.embedded.netty.NettyWebServer;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;

--- a/src/main/java/back/whats_your_ETF/service/StockListService.java
+++ b/src/main/java/back/whats_your_ETF/service/StockListService.java
@@ -3,11 +3,16 @@ package back.whats_your_ETF.service;
 import back.whats_your_ETF.dto.StockRankResponse;
 import back.whats_your_ETF.dto.StockResponse;
 import back.whats_your_ETF.entity.Ranking;
+import back.whats_your_ETF.repository.EmitterRepository;
 import back.whats_your_ETF.repository.RankingRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -15,6 +20,57 @@ import java.util.stream.Collectors;
 public class StockListService {
 
     private final RankingRepository rankingRepository;
+    private final EmitterRepository emitterRepository;
+
+    // SSE 연결 설정
+    public SseEmitter subscribeToStockUpdates() {
+        String id = "stock_updates_" + System.currentTimeMillis();
+        SseEmitter emitter = emitterRepository.save(id, new SseEmitter(60L * 1000 * 60)); // 60분 연결 유지
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(id));
+        emitter.onTimeout(() -> emitterRepository.deleteById(id));
+
+        return emitter;
+    }
+
+    // 5초마다 가격 변화를 감지하고 알림 전송
+    @Scheduled(fixedRate = 5000)
+    public void monitorPriceChanges() {
+        List<Ranking> rankings = rankingRepository.findAll();
+        for (Ranking ranking : rankings) {
+            Double currentPriceChangeRate = ranking.getPriceChangeRate();
+            Double cachedPriceChangeRate = emitterRepository.getCachedPriceChangeRate(ranking.getId());
+
+            // 가격 변화 감지
+            if (!currentPriceChangeRate.equals(cachedPriceChangeRate)) {
+                StockRankResponse response = convertToStockResponse(ranking);
+                sendPriceUpdate(response);
+
+                emitterRepository.updateCachedPriceChangeRate(ranking.getId(), currentPriceChangeRate);
+            }
+        }
+    }
+
+    // 실시간 업데이트 전송
+    private void sendPriceUpdate(StockRankResponse response) {
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllStartWithById("stock_updates");
+        sseEmitters.forEach((key, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event().id(key).name("price-update").data(response));
+            } catch (IOException e) {
+                emitterRepository.deleteById(key);
+            }
+        });
+    }
+
+    private StockRankResponse convertToStockResponse(Ranking ranking) {
+        return new StockRankResponse(
+                ranking.getStockCode(),
+                ranking.getStockName(),
+                ranking.getCurrentPrice() != null ? ranking.getCurrentPrice().doubleValue() : 0.0,
+                ranking.getPriceChangeRate()
+        );
+    }
 
     public List<StockRankResponse> getTop30ByFluctuation() {
         return rankingRepository.findTop30ByFluctuationRank()
@@ -46,14 +102,5 @@ public class StockListService {
                 .limit(30)
                 .map(this::convertToStockResponse)
                 .collect(Collectors.toList());
-    }
-
-    private StockRankResponse convertToStockResponse(Ranking ranking) {
-        return new StockRankResponse(
-                ranking.getStockCode(),
-                ranking.getStockName(),
-                ranking.getCurrentPrice() != null ? ranking.getCurrentPrice().doubleValue() : 0.0,
-                0.0
-        );
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
     show-sql: false
     properties:
       hibernate:
-        format_sql: trueportfolio
+        format_sql: true
   sql:
     init:
       mode: always


### PR DESCRIPTION
### 변경 사항
1. 실시간 주식 시세 변동 감지 및 SSE 전송 기능 구현
monitorPriceChanges 메서드:
- 주식 등락률(priceChangeRate)의 변화를 5초마다 감지.
- 값이 변동된 경우, SSE(Server-Sent Events)를 통해 클라이언트로 실시간 전송.
- 감지된 값은 캐시에 저장하여 이전 값과 비교.

2. SSE 구독(subscribeToStockUpdates):
- 클라이언트가 /api/stocks/subscribe 엔드포인트를 통해 실시간 알림을 구독할 수 있도록 설정.
- 60분 동안 연결 유지.
- Ranking 엔티티와 StockRankResponse를 활용한 데이터 전송

Ranking 엔티티에서 등락률(priceChangeRate)을 포함한 주식 데이터를 확인.
변경된 주식 정보를 StockRankResponse 형식으로 변환하여 클라이언트에 전송.